### PR TITLE
[r-ver] Remove the node Feature, add more comments, bump to version1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,3 @@ to using containers built from [rocker-org/devcontainer-images](https://github.c
 This repository is based on
 [the `devcontainers/templates` repository](https://github.com/devcontainers/templates) and
 [the `devcontainers/template-starter` repository](https://github.com/devcontainers/template-starter).
-
-Heavily under development.

--- a/src/r-ver/.devcontainer/devcontainer.json
+++ b/src/r-ver/.devcontainer/devcontainer.json
@@ -1,13 +1,16 @@
 {
 	"name": "R (rocker/r-ver base)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "ghcr.io/rocker-org/devcontainer/${templateOption:baseVariant}:${templateOption:imageVariant}",
-	"features": {}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "R --version",
+	// "postCreateCommand": "R -q -e 'renv::install()'",
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/src/r-ver/.devcontainer/devcontainer.json
+++ b/src/r-ver/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
 	"name": "R (rocker/r-ver base)",
 	"image": "ghcr.io/rocker-org/devcontainer/${templateOption:baseVariant}:${templateOption:imageVariant}",
-	"features": {
-		"ghcr.io/devcontainers/features/node:1": {
-			"version": "${templateOption:nodeVersion}"
-		}
-	}
+	"features": {}
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/src/r-ver/.devcontainer/devcontainer.json
+++ b/src/r-ver/.devcontainer/devcontainer.json
@@ -1,3 +1,5 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/rocker-org/devcontainer-templates/tree/main/src/r-ver
 {
 	"name": "R (rocker/r-ver base)",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile

--- a/src/r-ver/devcontainer-template.json
+++ b/src/r-ver/devcontainer-template.json
@@ -26,19 +26,6 @@
 				"geospatial"
 			],
 			"default": "r-ver"
-		},
-		"nodeVersion": {
-			"type": "string",
-			"description": "Node.js version:",
-			"proposals": [
-				"none",
-				"lts",
-				"latest",
-				"18",
-				"16",
-				"14"
-			],
-			"default": "lts"
 		}
 	},
 	"platforms": [

--- a/src/r-ver/devcontainer-template.json
+++ b/src/r-ver/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
 	"id": "r-ver",
-	"version": "0.2.0",
+	"version": "1.0.0",
 	"name": "R (rocker/r-ver base)",
 	"description": "A container-based development environment for the R language. Includes many commonly used R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-templates/tree/main/src/r-ver",

--- a/test/r-ver/test.sh
+++ b/test/r-ver/test.sh
@@ -4,9 +4,15 @@ cd "$(dirname "$0")" || exit
 # shellcheck source=/dev/null
 source test-utils.sh
 
-checkCommon
 check "R" R --version
 check "radian" radian --version
+check "languageserver" R -q -e 'packageVersion("languageserver")'
+check "httpgd" R -q -e 'packageVersion("httpgd")'
+check "rmarkdown" R -q -e 'packageVersion("rmarkdown")'
+check "devtools" R -q -e 'packageVersion("devtools")'
+check "pak" R -q -e 'packageVersion("pak")'
+check "renv" R -q -e 'packageVersion("renv")'
+check "vscDebugger" R -q -e 'packageVersion("vscDebugger")'
 
 # Report result
 reportResults


### PR DESCRIPTION
Close #14

Change the template to a simple image selection only.
Since I have recently enhanced the README, I expect to include a link to the README in the template so that users can read the documentation and learn how to customize the template.
(This is the same style as the official devcontainers' Templates.)