### PR TITLE
build: use DinD instead of DooD for development

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -15,10 +15,9 @@
 		}
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/docker-from-docker:1": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "latest"
 		}
 	},
-	"remoteUser": "node",
 	"postCreateCommand": "npm install -g @devcontainers/cli"
 }


### PR DESCRIPTION
This PR updates the Dev Container config to use Docker in Docker instead of Docker outside of Docker.

And remove unnecessary `remoteUser` field.