### PR TITLE
fix(r-ver,r2u): use `optionalPaths` for dependabot config file

### DIFF
--- a/src/r-ver/devcontainer-template.json
+++ b/src/r-ver/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
 	"id": "r-ver",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"name": "R (rocker/r-ver base)",
 	"description": "A container-based development environment for the R language. Includes many commonly used R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-templates/tree/main/src/r-ver",
@@ -30,5 +30,8 @@
 	},
 	"platforms": [
 		"R"
+	],
+	"optionalPaths": [
+		".github/*"
 	]
 }

--- a/src/r2u/devcontainer-template.json
+++ b/src/r2u/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
 	"id": "r2u",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"name": "R (r2u and bspm configured)",
 	"description": "Install R on Ubuntu and set r2u and bspm. (Only supports amd64)",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-templates/tree/main/src/r2u",
@@ -19,5 +19,8 @@
 	},
 	"platforms": [
 		"R"
+	],
+	"optionalPaths": [
+		".github/*"
 	]
 }


### PR DESCRIPTION
Same as devcontainers/templates#278